### PR TITLE
Was resetting the metrics upon opening circuitbreaker so opened excep…

### DIFF
--- a/core/src/main/scala/com/ccadllc/cedi/circuitbreaker/statistics/Statistics.scala
+++ b/core/src/main/scala/com/ccadllc/cedi/circuitbreaker/statistics/Statistics.scala
@@ -88,14 +88,14 @@ case class FailureStatistics private (
     case Some(testing) =>
       val updatedTesting = testing.update(timestamp, success)
       if (updatedTesting.successes >= config.test.minimumSuccesses)
-        copy(testing = None, change = Some(Change.Closed), lastActivity = timestamp)
+        copy(metrics = metrics.reset, testing = None, change = Some(Change.Closed), lastActivity = timestamp)
       else
         copy(testing = Some(updatedTesting), change = None, lastActivity = timestamp)
     case None =>
       val effectiveMetrics = metrics.addToWindow(timestamp, success)
       val tripsBreaker = effectiveMetrics.percentFailure greaterThan config.degradationThreshold
       if (tripsBreaker) copy(
-        metrics = effectiveMetrics.reset,
+        metrics = effectiveMetrics,
         testing = Some(Testing(config.test)),
         change = Some(Change.Opened),
         lastActivity = timestamp
@@ -311,7 +311,7 @@ object FlowControlStatistics {
     val meanInboundRate: MeanFlowRate = MeanFlowRate(inboundRate.mean)
     val meanProcessingRate: MeanFlowRate = MeanFlowRate(processingRate.mean)
 
-    val maxAcceptableRate: Option[MeanFlowRate] = if (inboundRate.fullWindowCollected)
+    val maxAcceptableRate: Option[MeanFlowRate] = if (inboundRate.fullWindowCollected && meanProcessingRate.perSecond > 0)
       Some(MeanFlowRate(meanProcessingRate.perSecond + (meanProcessingRate.perSecond * config.allowedOverProcessingRate.percent / 100.0))) else None
 
     def beforeThrottle(startTime: Instant): Metrics =


### PR DESCRIPTION
…tions and statistics showed failure rate as 0 - should be resetting just prior to closing instead - also should not calculate a max acceptable rate if the mean processing rate is zero, indicating no data has yet been processed in the range of time of the stats window (even though we've collected a window of data, we've since had a full window of no data).  review by @mpilquist 