### PR TITLE
Messaging was incorrect in throttling exception (said allowable rate …

### DIFF
--- a/core/src/main/scala/com/ccadllc/cedi/circuitbreaker/CircuitBreaker.scala
+++ b/core/src/main/scala/com/ccadllc/cedi/circuitbreaker/CircuitBreaker.scala
@@ -135,7 +135,7 @@ object CircuitBreaker {
       val reason = stats.metrics.inboundRate.currentSample.perSecondCount > stats.metrics.config.perSecondRateHardLimit match {
         case true => s"current requests per second (${stats.metrics.inboundRate.currentSample.perSecondCount} exceeding configured hard limit of ${stats.metrics.config.perSecondRateHardLimit})"
         case false => stats.maxAcceptableRate.fold(throw new IllegalStateException(s"Throttling without any acceptable max rate for ${stats.id}!")) { mar =>
-          s"allowable rate of ${mar.show} exceeding effective inbound rate of ${stats.meanInboundRate.show}"
+          s"allowable rate of ${mar.show} is less than effective inbound rate of ${stats.meanInboundRate.show}"
         }
       }
       s"throttled request due to $reason."


### PR DESCRIPTION
review by @matthughes or @mpilquist.  In a separate PR (that will need to be for a 1.2) I'm going to (re) introduce a minimum rate for throttling to fix an issue where when a low rate causes throttling because even with 10 percentage over allowed, a, say 0.3 effective allowable rate will cause throttling when getting a 0.8 effective inbound rate.