### PR TITLE
Added a throttling minimum to ensure that very low (fractions of a se…

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,16 @@ flow-control-circuitbreaker {
   # in effect act like a standard failure protection only variant.
   enabled: true
 
+  # This indicates the minimum inbound request per second mean which must be reached
+  # before throttling kicks in.  This helps reduce over-eager throttling at low rates
+  # where the allowed-over-processing-rate percentage may not be significant enough
+  # to otherwise avoid it. For example, an inbound rate of 0.8 and make allowed
+  # calculated as 0.3 will cause throttling even with allowed-over-processing-rate
+  # set to 10 percent.  In this case, setting the per-second-rate-minimum to
+  # 1 will ensure that throttling calculations will not occur until it reaches
+  # such a rate.  The default is 1
+  per-second-rate-minimum: 1
+
   # This indicates the hard limit for inbound requests per second.  If at any time the
   # number of requests per second exceed this value, requests will get throttled
   # until the start of the next second.  This is meant as a "failsafe" to
@@ -353,7 +363,7 @@ flow-control-circuitbreaker {
   # service can be handled in a sustained manner but not so high that it will
   # overwhelm the system for the period of time that it takes for the sample window
   # mean values to adjust to the increase in load and provide adaptive protection.
-  per-second-rate-threshold: 25
+  per-second-rate-hard-limit: 25
 }
 ```
 

--- a/core/src/main/scala/com/ccadllc/cedi/circuitbreaker/CircuitBreakerSettings.scala
+++ b/core/src/main/scala/com/ccadllc/cedi/circuitbreaker/CircuitBreakerSettings.scala
@@ -176,7 +176,8 @@ object FailureSettings {
  *   changed (either lower or higher) before a state change event is triggered.  If it is 0, all state changes result
  *   in an event.  This configuration item is meant to alleviate a flood of events when the request traffic pattern
  *   is very choppy (lots of spikes and valleys in a short time period).
- * @param perSecondHardLimit - this is the hard limit of the inbound requests per second above which requests will be
+ * @param perSecondRateMinimum - this is the minimum observed inbound rate at which flow control throttling will kick in.
+ * @param perSecondRateHardLimit - this is the hard limit of the inbound requests per second above which requests will be
  *   throttled by the circuit breaker (failed fast without execution) for the remainder of the current second.  It will
  *   be monitored and acted upon continuously.
  * @param enabled - The flow control portion of the [[CircuitBreaker]] can be enabled or disabled with this parameter.
@@ -186,10 +187,11 @@ case class FlowControlSettings(
     sampleWindow: SampleWindow,
     allowedOverProcessingRate: Percentage,
     minimumReportableRateChange: Percentage,
+    perSecondRateMinimum: Long,
     perSecondRateHardLimit: Long,
     enabled: Boolean = true
 ) {
-  def show: String = s"failure [ {failure.show} ], sample window [ ${sampleWindow.show} ], allowed over processing rate [ ${allowedOverProcessingRate.show} ], minimum reportable rate change [ ${minimumReportableRateChange.show} ], per second rate hard limit [ $perSecondRateHardLimit ], enabled [ $enabled ]"
+  def show: String = s"failure [ {failure.show} ], sample window [ ${sampleWindow.show} ], allowed over processing rate [ ${allowedOverProcessingRate.show} ], minimum reportable rate change [ ${minimumReportableRateChange.show} ], per second rate minimum [ $perSecondRateMinimum ], per second rate hard limit [ $perSecondRateHardLimit ], enabled [ $enabled ]"
 }
 object FlowControlSettings {
   implicit val configParser: ConfigParser[FlowControlSettings] = (
@@ -197,7 +199,8 @@ object FlowControlSettings {
     subconfig("sample-window")(SampleWindow.configParser) ~
     subconfig("allowed-over-processing-rate")(Percentage.configParser) ~
     subconfig("minimum-reportable-rate-change")(Percentage.configParser) ~
+    long("per-second-rate-minimum").withFallbackDefault(1L) ~
     long("per-second-rate-hard-limit") ~
     bool("enabled").withFallbackDefault(true)
-  ) map { case (f, sw, aopr, mrrc, psrhl, e) => FlowControlSettings(f, sw, aopr, mrrc, psrhl, e) }
+  ) map { case (f, sw, aopr, mrrc, psrm, psrhl, e) => FlowControlSettings(f, sw, aopr, mrrc, psrm, psrhl, e) }
 }

--- a/core/src/main/scala/com/ccadllc/cedi/circuitbreaker/statistics/Statistics.scala
+++ b/core/src/main/scala/com/ccadllc/cedi/circuitbreaker/statistics/Statistics.scala
@@ -382,9 +382,9 @@ case class FlowControlStatistics private (
     }
   } yield change
 
-  private def indicatesShouldBeThrottled(m: Metrics) = m.maxAcceptableRate.exists { m.meanInboundRate.perSecond > _.perSecond } || (
-    m.config.perSecondRateHardLimit > 0.0 && m.inboundRate.currentSample.perSecondCount > m.config.perSecondRateHardLimit
-  )
+  private def indicatesShouldBeThrottled(m: Metrics) = (
+    m.meanInboundRate.perSecond >= m.config.perSecondRateMinimum && m.maxAcceptableRate.exists { m.meanInboundRate.perSecond > _.perSecond }
+  ) || (m.config.perSecondRateHardLimit > 0L && m.inboundRate.currentSample.perSecondCount > m.config.perSecondRateHardLimit)
 }
 
 /**

--- a/core/src/test/scala/com/ccadllc/cedi/circuitbreaker/TestSupport.scala
+++ b/core/src/test/scala/com/ccadllc/cedi/circuitbreaker/TestSupport.scala
@@ -49,7 +49,7 @@ trait TestSupport extends WordSpecLike with Matchers {
   val testTestingConfig: FailureSettings.Test = FailureSettings.Test(2.seconds, 10)
   val testFailureConfig: FailureSettings = FailureSettings(SampleWindow(50.milliseconds), testDegradationThreshold, testTestingConfig)
   val testFlowControlConfig: FlowControlSettings = FlowControlSettings(
-    testFailureConfig, SampleWindow(4.seconds), Percentage.minimum, Percentage.minimum, 500
+    testFailureConfig, SampleWindow(4.seconds), Percentage.minimum, Percentage.minimum, 0L, 500L
   )
 
   class TestStreamedEventObserver {


### PR DESCRIPTION
…cond) rates where the percentage overage doesn't much help avoid over-eager throttling will not in fact cause such throttling (unless it is desired for some reason - I was going to hard code that it needed to be a whole number but there could be use cases where that doesn't apply; conversely, it helps avoid unnecessary processing if you know you can handle requests up to a limit).  I was also debating introducing a weighting factor to the overage value but the issue is really only fractions of requests per second).  This should be included in a 1.2 since it introduces a new configuration parameter.  review by @mpilquist or @matthughes 